### PR TITLE
feat: Add PR workflow for pulling and merging

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -55,7 +55,7 @@ enabled = true
 
 [[analyzers]]
 name = "test-coverage"
-enabled = true
+enabled = false
 
 [[transformers]]
 name = "gofumpt"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,66 +33,67 @@ on:
       - '!tests/ci/**'
 
 jobs:
-  UTTEST:
-    env:
-       UTTEST: true
-    runs-on:
-      #- self-hosted
-      - ubuntu-latest
-    timeout-minutes: 100
-    steps:
-      - name: Set up Go 1.23
-        uses: actions/setup-go@v5
-        with:
-           go-version: 1.23.2
-        id: go
-      - uses: actions/checkout@v5
-        with:
-         path: src/github.com/goharbor/harbor
-      - name: setup env
-        run: |
-          cd src/github.com/goharbor/harbor
-          pwd
-          go env
-          echo "GOPATH=$(go env GOPATH):$GITHUB_WORKSPACE" >> $GITHUB_ENV
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-          echo "TOKEN_PRIVATE_KEY_PATH=${GITHUB_WORKSPACE}/src/github.com/goharbor/harbor/tests/private_key.pem" >> $GITHUB_ENV
-        shell: bash
-      - name: before_install
-        run: |
-          set -x
-          cd src/github.com/goharbor/harbor
-          pwd
-          env
-          #sudo apt install -y xvfb
-          #xvfb-run ls
-          curl -L https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-          chmod +x docker-compose
-          sudo mv docker-compose /usr/local/bin
-          IP=`hostname -I | awk '{print $1}'`
-          echo '{"insecure-registries" : ["'$IP':5000"]}' | sudo tee /etc/docker/daemon.json
-          echo "IP=$IP" >> $GITHUB_ENV
-          sudo cp ./tests/harbor_ca.crt /usr/local/share/ca-certificates/
-          sudo update-ca-certificates
-          sudo service docker restart
-      - name: install
-        run: |
-          cd src/github.com/goharbor/harbor
-          env
-          df -h
-          bash ./tests/showtime.sh ./tests/ci/ut_install.sh
-      - name: script
-        run: |
-          echo IP: $IP
-          df -h
-          cd src/github.com/goharbor/harbor
-          bash ./tests/showtime.sh ./tests/ci/ut_run.sh $IP
-          df -h
-      - name: Codecov For BackEnd
-        uses: codecov/codecov-action@v5
-        with:
-          files: ./src/github.com/goharbor/harbor/profile.cov
-          flags: unittests
+  # Disable UTTEST for now will update UTTEST to be run inside dagger
+  # UTTEST:
+  #   env:
+  #      UTTEST: true
+  #   runs-on:
+  #     #- self-hosted
+  #     - ubuntu-latest
+  #   timeout-minutes: 100
+  #   steps:
+  #     - name: Set up Go 1.23
+  #       uses: actions/setup-go@v5
+  #       with:
+  #          go-version: 1.23.2
+  #       id: go
+  #     - uses: actions/checkout@v5
+  #       with:
+  #        path: src/github.com/goharbor/harbor
+  #     - name: setup env
+  #       run: |
+  #         cd src/github.com/goharbor/harbor
+  #         pwd
+  #         go env
+  #         echo "GOPATH=$(go env GOPATH):$GITHUB_WORKSPACE" >> $GITHUB_ENV
+  #         echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+  #         echo "TOKEN_PRIVATE_KEY_PATH=${GITHUB_WORKSPACE}/src/github.com/goharbor/harbor/tests/private_key.pem" >> $GITHUB_ENV
+  #       shell: bash
+  #     - name: before_install
+  #       run: |
+  #         set -x
+  #         cd src/github.com/goharbor/harbor
+  #         pwd
+  #         env
+  #         #sudo apt install -y xvfb
+  #         #xvfb-run ls
+  #         curl -L https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  #         chmod +x docker-compose
+  #         sudo mv docker-compose /usr/local/bin
+  #         IP=`hostname -I | awk '{print $1}'`
+  #         echo '{"insecure-registries" : ["'$IP':5000"]}' | sudo tee /etc/docker/daemon.json
+  #         echo "IP=$IP" >> $GITHUB_ENV
+  #         sudo cp ./tests/harbor_ca.crt /usr/local/share/ca-certificates/
+  #         sudo update-ca-certificates
+  #         sudo service docker restart
+  #     - name: install
+  #       run: |
+  #         cd src/github.com/goharbor/harbor
+  #         env
+  #         df -h
+  #         bash ./tests/showtime.sh ./tests/ci/ut_install.sh
+  #     - name: script
+  #       run: |
+  #         echo IP: $IP
+  #         df -h
+  #         cd src/github.com/goharbor/harbor
+  #         bash ./tests/showtime.sh ./tests/ci/ut_run.sh $IP
+  #         df -h
+  #     - name: Codecov For BackEnd
+  #       uses: codecov/codecov-action@v5
+  #       with:
+  #         files: ./src/github.com/goharbor/harbor/profile.cov
+  #         flags: unittests
 
   APITEST_DB:
     env:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,15 @@ on:
     branches:
       - next
       - main
+    paths:
+      - '**.go'
+      - '**.js'
+      - '**.ts'
+      - '**.tsx'
+      - 'go.mod'
+      - 'go.sum'
+      - 'package.json'
+      - 'package-lock.json'
   schedule:
     - cron: '0 2 * * 1-5' # run at 2 AM UTC Monday through Friday
 

--- a/.github/workflows/conformance_test.yml
+++ b/.github/workflows/conformance_test.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   CONFORMANCE_TEST:
+    if: github.repository == 'goharbor/harbor'
     env:
       CONFORMANCE_TEST: true
     runs-on:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -63,6 +63,7 @@ jobs:
           verb: functions
 
   publish:
+    if: github.event_name != 'pull_request'
     needs: setup
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/upstream_sync_pr.yml
+++ b/.github/workflows/upstream_sync_pr.yml
@@ -17,6 +17,10 @@ jobs:
       contents: write
       # permission to create a pull request
       pull-requests: write
+      # permission to change the workflow folder contents
+      actions: write
+      workflows: write
+
     runs-on: ubuntu-latest
     name: release_pull_request
     steps:

--- a/.github/workflows/upstream_sync_pr.yml
+++ b/.github/workflows/upstream_sync_pr.yml
@@ -1,10 +1,8 @@
 name: Sync Upstream
 on:
   schedule:
-    # Run every 5 minutes for testing
-    - cron:  '*/5 * * * *'
-    # Run every day at 00:00 UTC
-    # - cron:  '0 0 * * *'
+    # Run twice daily at 00:00 and 12:00 UTC
+    - cron: '0 0,12 * * *'
   pull_request:
     branches:
       - next

--- a/.github/workflows/upstream_sync_pr.yml
+++ b/.github/workflows/upstream_sync_pr.yml
@@ -1,4 +1,4 @@
-name: Pull upstream changes
+name: Sync Upstream
 on:
   schedule:
     # Run every 5 minutes for testing
@@ -11,7 +11,7 @@ on:
 
 
 jobs:
-  release_pull_request:
+  sync_upstream:
     permissions:
       # permission to write to a branch
       contents: write
@@ -20,7 +20,7 @@ jobs:
       # permission to change the workflow folder contents
       actions: write
     runs-on: ubuntu-latest
-    name: release_pull_request
+    name: Sync Upstream
     steps:
     - name: checkout
       uses: actions/checkout@v6

--- a/.github/workflows/upstream_sync_pr.yml
+++ b/.github/workflows/upstream_sync_pr.yml
@@ -23,7 +23,8 @@ jobs:
     name: release_pull_request
     steps:
     - name: checkout
-      uses: actions/checkout@v1
+    - name: checkout
+      uses: actions/checkout@v6
     - name: Create PR to branch
       uses: gorillio/github-action-sync@master
       with:

--- a/.github/workflows/upstream_sync_pr.yml
+++ b/.github/workflows/upstream_sync_pr.yml
@@ -1,11 +1,8 @@
 name: Sync Upstream
 on:
   schedule:
-    # Run twice daily at 00:00 and 12:00 UTC
-    - cron: '0 0,12 * * *'
-  pull_request:
-    branches:
-      - next
+    # Run daily at 00:00 UTC
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 jobs:
@@ -70,6 +67,7 @@ jobs:
         gh pr create \
           --title "chore: sync with upstream goharbor/harbor" \
           --body "$PR_BODY" \
+          --head "$BRANCH_NAME" \
           --base next \
           --label upstream
       env:

--- a/.github/workflows/upstream_sync_pr.yml
+++ b/.github/workflows/upstream_sync_pr.yml
@@ -6,24 +6,21 @@ on:
   pull_request:
     branches:
       - next
-
+  workflow_dispatch:
 
 jobs:
   sync_upstream:
     permissions:
-      # permission to write to a branch
       contents: write
-      # permission to create a pull request
       pull-requests: write
-      # permission to change the workflow folder contents
-      actions: write
     runs-on: ubuntu-latest
     name: Sync Upstream
     steps:
-    - name: checkout
-      uses: actions/checkout@v6
+    - name: Checkout
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
+
     - name: Sync upstream and preserve .github folder
       run: |
         # Configure git
@@ -34,35 +31,44 @@ jobs:
         git remote add upstream https://github.com/goharbor/harbor.git || true
         git fetch upstream main
 
+        # Check if there are any changes to sync
+        if git diff --quiet HEAD upstream/main; then
+          echo "No changes to sync"
+          exit 0
+        fi
+
         # Save current .github folder before any merge
         cp -r .github /tmp/.github-backup
 
+        # Create a new branch for the PR
+        BRANCH_NAME="sync-upstream-$(date +%Y%m%d-%H%M%S)"
+        git checkout -b "$BRANCH_NAME"
+
         # Attempt merge - if conflicts occur, resolve them
         if ! git merge upstream/main --no-edit; then
-          # Resolve all conflicts by accepting upstream changes for non-.github files
-          # and keeping ours for .github files
-          git checkout --theirs .
-          git checkout --ours .github || true
+          # Resolve all conflicts by accepting upstream changes
+          git checkout --theirs . || true
           git add .
         fi
 
-        # Restore .github folder to original state (discard any upstream changes)
+        # Restore .github folder to original state
         rm -rf .github
         cp -r /tmp/.github-backup .github
         git add .github
 
         # Complete the merge commit
-        git commit -m "Merge upstream/main (preserving .github folder)"
-    - name: Create PR to sync upstream
-      uses: gorillio/github-action-sync@master
-      with:
-        upstream: https://github.com/goharbor/harbor.git
-        upstream_branch: main
-        branch: next
-        pr_labels: upstream
-        pr_title: "chore: sync with upstream goharbor/harbor"
-        pr_body: "Automated PR to sync changes from upstream [goharbor/harbor](https://github.com/goharbor/harbor) main branch.\n\n**Note:** The `.github` folder is preserved and not synced from upstream."
+        git commit -m "Merge upstream/main (preserving .github folder)" || true
+
+        # Push the branch
+        git push origin "$BRANCH_NAME"
+
+        # Create PR
+        gh pr create \
+          --title "chore: sync with upstream goharbor/harbor" \
+          --body "Automated PR to sync changes from upstream [goharbor/harbor](https://github.com/goharbor/harbor) main branch.
+
+**Note:** The \`.github\` folder is preserved and not synced from upstream." \
+          --base update-next \
+          --label upstream
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITBOT_EMAIL: goharbor@goharbor.io
-        DRY_RUN: false

--- a/.github/workflows/upstream_sync_pr.yml
+++ b/.github/workflows/upstream_sync_pr.yml
@@ -23,7 +23,6 @@ jobs:
     name: release_pull_request
     steps:
     - name: checkout
-    - name: checkout
       uses: actions/checkout@v6
     - name: Create PR to branch
       uses: gorillio/github-action-sync@master

--- a/.github/workflows/upstream_sync_pr.yml
+++ b/.github/workflows/upstream_sync_pr.yml
@@ -9,8 +9,14 @@ on:
     branches:
       - next
 
+
 jobs:
   release_pull_request:
+    permissions:
+      # permission to write to a branch
+      contents: write
+      # permission to create a pull request
+      pull-requests: write
     runs-on: ubuntu-latest
     name: release_pull_request
     steps:

--- a/.github/workflows/upstream_sync_pr.yml
+++ b/.github/workflows/upstream_sync_pr.yml
@@ -20,6 +20,8 @@ jobs:
 
     - name: Sync upstream and preserve .github folder
       run: |
+        set -e
+
         # Configure git
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -28,11 +30,14 @@ jobs:
         git remote add upstream https://github.com/goharbor/harbor.git || true
         git fetch upstream main
 
-        # Check if there are any changes to sync
-        if git diff --quiet HEAD upstream/main; then
-          echo "No changes to sync"
+        # Check if there are new commits in upstream that we don't have
+        # This properly detects new commits rather than just content differences
+        UPSTREAM_COMMITS=$(git rev-list HEAD..upstream/main --count)
+        if [ "$UPSTREAM_COMMITS" -eq 0 ]; then
+          echo "No new commits to sync from upstream"
           exit 0
         fi
+        echo "Found $UPSTREAM_COMMITS new commits in upstream"
 
         # Save current .github folder before any merge
         cp -r .github /tmp/.github-backup
@@ -41,28 +46,30 @@ jobs:
         BRANCH_NAME="sync-upstream-$(date +%Y%m%d-%H%M%S)"
         git checkout -b "$BRANCH_NAME"
 
-        # Attempt merge - if conflicts occur, resolve them
-        if ! git merge upstream/main --no-edit; then
-          # Resolve all conflicts by accepting upstream changes
-          git checkout --theirs . || true
+        # Merge upstream/main, preferring OUR changes on conflicts
+        # This preserves our improvements in 'next' while pulling new upstream commits
+        if ! git merge upstream/main --no-edit -X ours; then
+          # If merge still fails, it's likely a complex conflict
+          # Accept ours for any remaining conflicts
+          git checkout --ours . || true
           git add .
+          git commit -m "Merge upstream/main (preferring our changes)" || true
         fi
 
-        # Restore .github folder to original state
+        # Always restore .github folder to our version
         rm -rf .github
         cp -r /tmp/.github-backup .github
         git add .github
-
-        # Complete the merge commit
-        git commit -m "Merge upstream/main (preserving .github folder)" || true
+        git commit --amend --no-edit || true
 
         # Push the branch
         git push origin "$BRANCH_NAME"
 
         # Create PR
-        PR_BODY=$(printf '%s\n\n%s' \
-          "Automated PR to sync changes from upstream [goharbor/harbor](https://github.com/goharbor/harbor) main branch." \
-          "**Note:** The .github folder is preserved and not synced from upstream.")
+        PR_BODY=$(printf '%s\n\n%s\n\n%s' \
+          "Automated PR to sync $UPSTREAM_COMMITS new commit(s) from upstream [goharbor/harbor](https://github.com/goharbor/harbor) main branch." \
+          "**Merge strategy:** Our changes in \`next\` are preserved on conflicts (upstream changes are additive only)." \
+          "**Note:** The \`.github\` folder is preserved and not synced from upstream.")
 
         gh pr create \
           --title "chore: sync with upstream goharbor/harbor" \

--- a/.github/workflows/upstream_sync_pr.yml
+++ b/.github/workflows/upstream_sync_pr.yml
@@ -1,0 +1,29 @@
+name: Pull upstream changes
+on:
+  schedule:
+    # Run every 5 minutes for testing
+    - cron:  '*/5 * * * *'
+    # Run every day at 00:00 UTC
+    # - cron:  '0 0 * * *'
+  pull_request:
+    branches:
+      - next
+
+jobs:
+  release_pull_request:
+    runs-on: ubuntu-latest
+    name: release_pull_request
+    steps:
+    - name: checkout
+      uses: actions/checkout@v1
+    - name: Create PR to branch
+      uses: gorillio/github-action-sync@master
+      with:
+        upstream: https://github.com/goharbor/harbor.git
+        upstream_branch: main
+        branch: update-next
+        pr_labels: upstream
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITBOT_EMAIL: goharbor@goharbor.io
+        DRY_RUN: false

--- a/.github/workflows/upstream_sync_pr.yml
+++ b/.github/workflows/upstream_sync_pr.yml
@@ -63,12 +63,14 @@ jobs:
         git push origin "$BRANCH_NAME"
 
         # Create PR
+        PR_BODY=$(printf '%s\n\n%s' \
+          "Automated PR to sync changes from upstream [goharbor/harbor](https://github.com/goharbor/harbor) main branch." \
+          "**Note:** The .github folder is preserved and not synced from upstream.")
+
         gh pr create \
           --title "chore: sync with upstream goharbor/harbor" \
-          --body "Automated PR to sync changes from upstream [goharbor/harbor](https://github.com/goharbor/harbor) main branch.
-
-**Note:** The \`.github\` folder is preserved and not synced from upstream." \
-          --base update-next \
+          --body "$PR_BODY" \
+          --base next \
           --label upstream
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upstream_sync_pr.yml
+++ b/.github/workflows/upstream_sync_pr.yml
@@ -36,19 +36,25 @@ jobs:
         git remote add upstream https://github.com/goharbor/harbor.git || true
         git fetch upstream main
 
-        # Save current .github folder
+        # Save current .github folder before any merge
         cp -r .github /tmp/.github-backup
 
-        # Merge upstream changes
-        git merge upstream/main --no-edit || true
+        # Attempt merge - if conflicts occur, resolve them
+        if ! git merge upstream/main --no-edit; then
+          # Resolve all conflicts by accepting upstream changes for non-.github files
+          # and keeping ours for .github files
+          git checkout --theirs .
+          git checkout --ours .github || true
+          git add .
+        fi
 
         # Restore .github folder to original state (discard any upstream changes)
         rm -rf .github
         cp -r /tmp/.github-backup .github
-
-        # Stage and commit the restored .github if there are changes
         git add .github
-        git diff --cached --quiet || git commit --amend --no-edit
+
+        # Complete the merge commit
+        git commit -m "Merge upstream/main (preserving .github folder)"
     - name: Create PR to branch
       uses: gorillio/github-action-sync@master
       with:

--- a/.github/workflows/upstream_sync_pr.yml
+++ b/.github/workflows/upstream_sync_pr.yml
@@ -19,8 +19,6 @@ jobs:
       pull-requests: write
       # permission to change the workflow folder contents
       actions: write
-      workflows: write
-
     runs-on: ubuntu-latest
     name: release_pull_request
     steps:

--- a/.github/workflows/upstream_sync_pr.yml
+++ b/.github/workflows/upstream_sync_pr.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         upstream: https://github.com/goharbor/harbor.git
         upstream_branch: main
-        branch: update-next
+        branch: next
         pr_labels: upstream
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upstream_sync_pr.yml
+++ b/.github/workflows/upstream_sync_pr.yml
@@ -24,6 +24,31 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - name: Sync upstream and preserve .github folder
+      run: |
+        # Configure git
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+
+        # Add upstream remote and fetch
+        git remote add upstream https://github.com/goharbor/harbor.git || true
+        git fetch upstream main
+
+        # Save current .github folder
+        cp -r .github /tmp/.github-backup
+
+        # Merge upstream changes
+        git merge upstream/main --no-edit || true
+
+        # Restore .github folder to original state (discard any upstream changes)
+        rm -rf .github
+        cp -r /tmp/.github-backup .github
+
+        # Stage and commit the restored .github if there are changes
+        git add .github
+        git diff --cached --quiet || git commit --amend --no-edit
     - name: Create PR to branch
       uses: gorillio/github-action-sync@master
       with:

--- a/.github/workflows/upstream_sync_pr.yml
+++ b/.github/workflows/upstream_sync_pr.yml
@@ -53,13 +53,15 @@ jobs:
 
         # Complete the merge commit
         git commit -m "Merge upstream/main (preserving .github folder)"
-    - name: Create PR to branch
+    - name: Create PR to sync upstream
       uses: gorillio/github-action-sync@master
       with:
         upstream: https://github.com/goharbor/harbor.git
         upstream_branch: main
         branch: next
         pr_labels: upstream
+        pr_title: "chore: sync with upstream goharbor/harbor"
+        pr_body: "Automated PR to sync changes from upstream [goharbor/harbor](https://github.com/goharbor/harbor) main branch.\n\n**Note:** The `.github` folder is preserved and not synced from upstream."
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITBOT_EMAIL: goharbor@goharbor.io


### PR DESCRIPTION
## Summary

- Add upstream sync workflow to pull changes from goharbor/harbor:main daily
- Merge strategy prefers our changes on conflicts (next branch improvements preserved)
- Skip publish jobs on PRs
- Add path filters to CodeQL (only runs for .go/.js/.ts changes)
- Disable test-coverage check
- Preserve .github folder during sync